### PR TITLE
Remove hardcoded Deepgram endpoints for privacy

### DIFF
--- a/screenpipe-audio/src/transcription/deepgram/mod.rs
+++ b/screenpipe-audio/src/transcription/deepgram/mod.rs
@@ -5,8 +5,8 @@ use lazy_static::lazy_static;
 use std::env;
 
 lazy_static! {
-    pub(crate) static ref DEEPGRAM_API_URL: String = env::var("DEEPGRAM_API_URL")
-        .unwrap_or_else(|_| "https://api.deepgram.com/v1/listen".to_string());
+    pub(crate) static ref DEEPGRAM_API_URL: String =
+        env::var("DEEPGRAM_API_URL").unwrap_or_else(|_| String::new());
     pub(crate) static ref DEEPGRAM_WEBSOCKET_URL: String =
         env::var("DEEPGRAM_WEBSOCKET_URL").unwrap_or_else(|_| String::new());
     pub(crate) static ref CUSTOM_DEEPGRAM_API_TOKEN: String =

--- a/screenpipe-core/examples/win_automation.rs
+++ b/screenpipe-core/examples/win_automation.rs
@@ -43,9 +43,6 @@ fn main() -> Result<(), AutomationError> {
     // let opened_app = engine.open_application("msedge")?;
     // println!("opened application: {:?}", opened_app);
 
-    // open a URL in a browser
-    // let ele = engine.open_url("https://github.com", Some("msedge"))?;
-    // println!("ele: {:?}", ele);
 
     // perform actions on an element
     // get root of an application
@@ -183,9 +180,7 @@ remind about maintenance renewal coming up in December";
 
         // --- Part 3: Open Google Sheets and Input Data ---
         println!("Opening Google Sheets...");
-        let sheets_app = engine.open_url("https://docs.google.com/spreadsheets/d/1u2vPS43pkFdIrtWbl4Ug7D1ROmrtSD-YTo24FwGqDdo/edit?gid=0#gid=0", None)?;
-        // let sheets_app = engine.open_url("https://docs.google.com/spreadsheets/u/1/", None)?;
-        println!("Sheets opened: {:?}", sheets_app.attributes());
+        println!("Sheets opened");
         // Wait for Sheets to load
         // thread::sleep(Duration::from_secs(5)); 
 

--- a/screenpipe-js/ai-proxy/src/handlers/transcription.ts
+++ b/screenpipe-js/ai-proxy/src/handlers/transcription.ts
@@ -15,14 +15,15 @@ export async function handleFileTranscription(request: Request, env: Env): Promi
     const sampleRate = request.headers.get('sample_rate') || '16000';
     
     const deepgramResponse = await fetch(
-      'https://api.deepgram.com/v1/listen?model=nova-3&smart_format=true&sample_rate=' +
+      env.DEEPGRAM_API_URL +
+        '?model=nova-3&smart_format=true&sample_rate=' +
         sampleRate +
         (languages.length > 0 ? '&' + languages.map((lang) => `detect_language=${lang}`).join('&') : ''),
       {
         method: 'POST',
         headers: {
           Authorization: `Token ${env.DEEPGRAM_API_KEY}`,
-          'Content-Type': 'audio/wav', 
+          'Content-Type': 'audio/wav',
         },
         body: audioBuffer,
       }
@@ -56,7 +57,7 @@ export async function handleWebSocketUpgrade(request: Request, env: Env): Promis
     server.accept();
 
     let params = new URL(request.url).searchParams;
-    let url = new URL('wss://api.deepgram.com/v1/listen');
+    let url = new URL(env.DEEPGRAM_WEBSOCKET_URL);
     
     for (let [key, value] of params.entries()) {
       url.searchParams.set(key, value);

--- a/screenpipe-js/ai-proxy/src/types.ts
+++ b/screenpipe-js/ai-proxy/src/types.ts
@@ -116,9 +116,11 @@ export interface Env {
 	OPENAI_API_KEY: string;
 	LANGFUSE_PUBLIC_KEY: string;
 	LANGFUSE_SECRET_KEY: string;
-	ANTHROPIC_API_KEY: string;
-	DEEPGRAM_API_KEY: string;
-	RATE_LIMITER: DurableObjectNamespace;
+        ANTHROPIC_API_KEY: string;
+        DEEPGRAM_API_KEY: string;
+        DEEPGRAM_API_URL: string;
+        DEEPGRAM_WEBSOCKET_URL: string;
+        RATE_LIMITER: DurableObjectNamespace;
 	CLERK_SECRET_KEY: string;
 	GEMINI_API_KEY: string;
 	SUPABASE_URL: string;

--- a/screenpipe-js/ai-proxy/src/utils/voice-utils.ts
+++ b/screenpipe-js/ai-proxy/src/utils/voice-utils.ts
@@ -186,7 +186,7 @@ export async function textToSpeech(text: string, env: Env, options: TTSOptions =
 		console.log(`Converting text to speech using voice: ${voice}, encoding: ${encoding}`);
 		console.log(`Text length: ${text.length} characters`);
 
-		const url = new URL('https://api.deepgram.com/v1/speak');
+                const url = new URL(env.DEEPGRAM_API_URL);
 		url.searchParams.set('model', voice);
 
 		if (encoding !== 'linear16') {


### PR DESCRIPTION
## Summary
- Route Deepgram requests through environment-defined URLs
- Drop external URL examples from Windows automation demo

## Testing
- `cargo test` *(fails: missing `alsa` system library)*
- `npm test` in `screenpipe-js/ai-proxy` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a25988a6d0832dab0956ccb10e87de