### PR TITLE
Improve pre_build triple detection and add CI pre-build checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
           export PKG_CONFIG_ALLOW_CROSS=1
           export RUSTFLAGS="-C link-arg=-Wl,-rpath,@executable_path/../lib -C link-arg=-Wl,-rpath,@loader_path/../lib"
           cargo build --release --features metal --target aarch64-apple-darwin
+      - run: node ./scripts/pre_build.cjs
+        working-directory: screenpipe-app-tauri
       - run: |
           VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.0)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
@@ -129,6 +131,8 @@ jobs:
           run_install: false
       - uses: oven-sh/setup-bun@v1
       - run: cargo build --release --target x86_64-unknown-linux-gnu
+      - run: node ./scripts/pre_build.cjs
+        working-directory: screenpipe-app-tauri
       - run: |
           VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.0)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
@@ -194,6 +198,9 @@ jobs:
           echo RUSTFLAGS=$env:RUSTFLAGS
         shell: pwsh
       - run: cargo build --release --target x86_64-pc-windows-msvc -vv
+        shell: pwsh
+      - run: node ./scripts/pre_build.cjs
+        working-directory: screenpipe-app-tauri
         shell: pwsh
       - run: |
           $files = Get-ChildItem "target/x86_64-pc-windows-msvc/release" -Include *.obj,*.lib -Recurse -ErrorAction SilentlyContinue

--- a/screenpipe-app-tauri/scripts/pre_build.cjs
+++ b/screenpipe-app-tauri/scripts/pre_build.cjs
@@ -9,10 +9,12 @@ const destDir = path.join(root, "src-tauri", "bin");
 const plat = os.platform();
 const envTriple = process.env.SCREENPIPE_TARGET_TRIPLE;
 
+const arch = os.arch();
 const defaultTriple =
   plat === "win32" ? "x86_64-pc-windows-msvc" :
   plat === "linux" ? "x86_64-unknown-linux-gnu" :
-  "aarch64-apple-darwin";
+  arch === "arm64" ? "aarch64-apple-darwin" :
+  "x86_64-apple-darwin";
 
 const triple = envTriple || defaultTriple;
 const exeName = plat === "win32" ? "screenpipe.exe" : "screenpipe";


### PR DESCRIPTION
## Summary
- handle macOS architecture when selecting default target triple in pre_build script
- run pre_build script in CI from app directory to ensure binaries are prepared on all platforms

## Testing
- `SCREENPIPE_TARGET_TRIPLE=x86_64-unknown-linux-gnu node screenpipe-app-tauri/scripts/pre_build.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68a3d9cedb24832d9f2e83d9e59f9216