### PR TITLE
refactor: clean clippy cfg and align windows deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ vcpkg = "0.2"
 cc = "1.0"
 oasgen = { version = "0.22.0", features = ["axum", "chrono"] }
 once_cell = "1.20.2"
+windows = "0.58.0"
+windows-core = "0.58.0"
+windows-targets = "0.58.0"
+windows-sys = "0.58.0"
 
 http-cache-reqwest = "0.15.0"
 reqwest = { version = "=0.12.12", features = ["blocking", "multipart", "json"] }
@@ -58,8 +62,6 @@ hf-hub = { git = "https://github.com/neo773/hf-hub", features = ["native-tls"] }
 # Patch half to use a version compatible with both candle and ort
 half = { git = "https://github.com/starkat99/half-rs.git", tag = "v2.5.0" }
 knf-rs-sys = { path = "vendor/knf-rs-sys" }
-windows = { git = "https://github.com/microsoft/windows-rs", tag = "0.53.0" }
-windows-core = { git = "https://github.com/microsoft/windows-rs", tag = "0.60.0", package = "windows-core" }
 
 [patch."https://github.com/Neptune650/knf-rs.git"]
 knf-rs-sys = { path = "vendor/knf-rs-sys" }

--- a/screenpipe-core/src/operator/platforms/macos.rs
+++ b/screenpipe-core/src/operator/platforms/macos.rs
@@ -172,7 +172,6 @@ impl MacOSEngine {
     }
 
     // Add this new method to refresh the accessibility tree
-    #[allow(clippy::unexpected_cfg_condition)]
     pub fn refresh_accessibility_tree(
         &self,
         app_name: Option<&str>,
@@ -407,7 +406,6 @@ fn macos_role_to_generic_role(role: &str) -> Vec<String> {
     }
 }
 // Helper function to get PIDs of running applications using NSWorkspace
-#[allow(clippy::unexpected_cfg_condition)]
 fn get_running_application_pids(use_background_apps: bool) -> Result<Vec<i32>, AutomationError> {
     // Implementation using Objective-C bridging
     unsafe {

--- a/screenpipe-server/Cargo.toml
+++ b/screenpipe-server/Cargo.toml
@@ -145,7 +145,7 @@ ignored = ["url", "console-subscriber"]
 nix = { version = "0.29", features = ["signal"] }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58", features = [
+windows = { workspace = true, features = [
     "Win32_System_Threading",
     "Win32_Foundation",
 ] }

--- a/screenpipe-vision/Cargo.toml
+++ b/screenpipe-vision/Cargo.toml
@@ -79,7 +79,7 @@ path = "examples/websocket.rs"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 uiautomation = { version = "0.16.1" }
-windows = { version = "0.58", features = [
+windows = { workspace = true, features = [
   "Graphics_Imaging",
   "Media_Ocr",
   "Storage",


### PR DESCRIPTION
## Summary
- remove leftover clippy cfg guards on macOS operator
- align Windows crate versions via workspace dependencies

## Testing
- `cargo check --all-targets --workspace` *(fails: Failed to GET https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.19.2/ortrs_static-v1.19.2-x86_64-unknown-linux-gnu.tgz)*
- `cargo clippy --all-targets --workspace -q` *(fails: Failed to GET https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.19.2/ortrs_static-v1.19.2-x86_64-unknown-linux-gnu.tgz)*
- `cargo build --release --target x86_64-pc-windows-msvc` *(fails: can't find crate for `core`)*
- `pnpm --prefix screenpipe-app-tauri install`
- `pnpm --prefix screenpipe-app-tauri run tauri build -- -vvv` *(fails: screenpipe binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e6f4a324832d80edb16fb094962c