### PR TITLE
fix: stabilize ci build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,11 @@ jobs:
       - run: brew install ffmpeg pkg-config
       - run: brew link --overwrite pkg-config
       - run: |
-          export PKG_CONFIG_PATH="/usr/local/opt/ffmpeg/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export PKG_CONFIG_PATH="$(brew --prefix ffmpeg)/lib/pkgconfig:$PKG_CONFIG_PATH"
           export PKG_CONFIG_ALLOW_CROSS=1
           export RUSTFLAGS="-Awarnings -C link-arg=-Wl,-rpath,@executable_path/../lib -C link-arg=-Wl,-rpath,@loader_path/../lib"
           export RUSTDOCFLAGS=-Awarnings
-          cargo build --release -p screenpipe --target aarch64-apple-darwin
+          cargo build --release -p screenpipe-server --target aarch64-apple-darwin
       - run: node ./scripts/pre_build.cjs
         working-directory: screenpipe-app-tauri
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,27 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Metadata
+        if: runner.os != 'Windows'
+        run: cargo metadata --format-version 1 | jq -r '.packages[].name'
+
+      - name: Metadata (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          (cargo metadata --format-version 1) | ConvertFrom-Json | % packages | % name
+
+      - name: Configure FFmpeg
+        if: runner.os == 'macOS'
+        run: |
+          echo "PKG_CONFIG_PATH=$(brew --prefix ffmpeg)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+          pkg-config --exists libavcodec
+          pkg-config --exists libavformat
+
+      - name: Clean
+        if: runner.os == 'Windows'
+        run: cargo clean -p screenpipe-vision
+
       - name: Build
         run: cargo build --workspace --all-targets --verbose
 

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -462,7 +462,7 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.os_type }}" == "macos" ]]; then
-            export PKG_CONFIG_PATH="/usr/local/opt/ffmpeg/lib/pkgconfig:$PKG_CONFIG_PATH"
+            export PKG_CONFIG_PATH="$(brew --prefix ffmpeg)/lib/pkgconfig:$PKG_CONFIG_PATH"
             export PKG_CONFIG_ALLOW_CROSS=1
           fi
           cargo build --release -p screenpipe-server ${{ matrix.args }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -45,7 +45,7 @@ on:
 
       - name: Build with Metal feature
         run: |
-          export PKG_CONFIG_PATH="/usr/local/opt/ffmpeg/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export PKG_CONFIG_PATH="$(brew --prefix ffmpeg)/lib/pkgconfig:$PKG_CONFIG_PATH"
           export PKG_CONFIG_ALLOW_CROSS=1
           export RUSTFLAGS="-C link-arg=-Wl,-rpath,@executable_path/../lib -C link-arg=-Wl,-rpath,@loader_path/../lib"
           cargo build --release --features metal --target ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,7 +3788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6413,7 +6413,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
- "windows 0.52.0",
+ "windows 0.59.0",
 ]
 
 [[package]]
@@ -6453,7 +6453,7 @@ dependencies = [
  "uiautomation",
  "url",
  "which 6.0.3",
- "windows 0.52.0",
+ "windows 0.59.0",
  "xcap",
  "zbus",
 ]
@@ -8724,16 +8724,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,8 @@ vcpkg = "0.2"
 cc = "1.0"
 oasgen = { version = "0.22.0", features = ["axum", "chrono"] }
 once_cell = "1.20.2"
-windows = "0.52.0"
-windows-core = "0.52.0"
-windows-targets = "0.52.0"
-windows-sys = "0.52.0"
+windows = "0.59.0"
+windows-core = "0.59.0"
 ort = { version = "=2.0.0-rc.10", default-features = false, features = ["load-dynamic", "ndarray"] }
 ort-sys = { version = "=2.0.0-rc.10", default-features = false, features = ["load-dynamic"] }
 ndarray = "0.16"
@@ -61,8 +59,8 @@ reqwest-middleware = "0.4.1"
 
 
 [patch.crates-io]
-# enables chinese mirror (hf is banned in china) and native-tls
-hf-hub = { git = "https://github.com/neo773/hf-hub", features = ["native-tls"] }
+# enables chinese mirror (hf is banned in china)
+hf-hub = { git = "https://github.com/neo773/hf-hub" }
 # Patch half to use a version compatible with both candle and ort
 half = { git = "https://github.com/starkat99/half-rs.git", tag = "v2.5.0" }
 knf-rs-sys = { path = "vendor/knf-rs-sys" }

--- a/screenpipe-audio/Cargo.toml
+++ b/screenpipe-audio/Cargo.toml
@@ -33,7 +33,7 @@ chrono = { version = "0.4.31", features = ["serde"] }
 # Local Embeddings + STT
 vad-rs = { version = "0.1.5", default-features = false, features = ["helpers", "load-dynamic"] }
 anyhow = "1.0.86"
-hf-hub = "0.3.2"
+hf-hub = { workspace = true }
 # https://github.com/pdeljanov/Symphonia/tree/master?tab=readme-ov-file#optimizations
 symphonia = { version = "0.5.4", features = ["aac", "isomp4", "opt-simd"] }
 rubato = "0.15.0"

--- a/screenpipe-vision/Cargo.toml
+++ b/screenpipe-vision/Cargo.toml
@@ -48,7 +48,7 @@ base64 = "0.22.1"
 reqwest = { workspace = true }
 
 [dependencies.windows]
-version = "0.52"
+workspace = true
 features = [
     "Foundation",
     "Graphics_Imaging",

--- a/screenpipe-vision/src/microsoft.rs
+++ b/screenpipe-vision/src/microsoft.rs
@@ -29,7 +29,7 @@ pub async fn perform_ocr_windows(image: &DynamicImage) -> Result<(String, String
     writer.FlushAsync()?.await?;
     stream.Seek(0)?;
 
-    let decoder = BitmapDecoder::CreateAsync(BitmapDecoder::PngDecoderId()?, &stream)?.await?;
+    let decoder = BitmapDecoder::CreateWithIdAsync(&BitmapDecoder::PngDecoderId()?, &stream)?.await?;
 
     let bitmap: SoftwareBitmap = decoder.GetSoftwareBitmapAsync()?.await?;
 


### PR DESCRIPTION
## Summary
- unify windows crate versions and remove hf-hub patch features
- fix WinRT decoder call and correct workspace metadata steps in CI
- set up dynamic ffmpeg paths on macOS workflows

## Testing
- `cargo check -p screenpipe-vision --target x86_64-pc-windows-msvc` *(fails: failed to find tool "lib.exe")*
- `cargo test --workspace` *(terminated: exceeded time)*

------
https://chatgpt.com/codex/tasks/task_e_68a442bb7660832db3257eb7f1185fa6