### PR TITLE
fix: remove stub binary and ensure glib deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ screenpipe
 make sure to allow permissions on macos (screen, mic)
 
 - [get the desktop app](https://screenpi.pe/)
+- [glib-2.0](https://developer.gnome.org/glib/)
+- [gobject-2.0](https://developer.gnome.org/gobject/)
 - [docs & build from source](https://docs.screenpi.pe/getting-started)
 
 ## create plugins

--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,8 @@ if [ "$os" = "unknown-linux-gnu" ]; then
     # Check for required libraries
     NEED_ALSA=0
     NEED_FFMPEG=0
+    NEED_GLIB=0
+    NEED_GOBJECT=0
 
     if ! ldconfig -p | grep -q "libasound.so.2" >/dev/null 2>&1; then
         NEED_ALSA=1
@@ -77,32 +79,42 @@ if [ "$os" = "unknown-linux-gnu" ]; then
     if ! command -v ffmpeg >/dev/null 2>&1; then
         NEED_FFMPEG=1
     fi
+    if ! pkg-config --exists glib-2.0 >/dev/null 2>&1; then
+        NEED_GLIB=1
+    fi
+    if ! pkg-config --exists gobject-2.0 >/dev/null 2>&1; then
+        NEED_GOBJECT=1
+    fi
 
     # Install missing dependencies based on package manager
-    if [ $NEED_ALSA -eq 1 ] || [ $NEED_FFMPEG -eq 1 ]; then
+    if [ $NEED_ALSA -eq 1 ] || [ $NEED_FFMPEG -eq 1 ] || [ $NEED_GLIB -eq 1 ] || [ $NEED_GOBJECT -eq 1 ]; then
         if command -v apt-get >/dev/null 2>&1; then
             # Ubuntu/Debian
             PKGS=""
             [ $NEED_ALSA -eq 1 ] && PKGS="$PKGS libasound2-dev" && echo "installing libasound2-dev..."
             [ $NEED_FFMPEG -eq 1 ] && PKGS="$PKGS ffmpeg" && echo "installing ffmpeg..."
+            if [ $NEED_GLIB -eq 1 ] || [ $NEED_GOBJECT -eq 1 ]; then PKGS="$PKGS libglib2.0-dev" && echo "installing libglib2.0-dev..."; fi
             sudo apt-get install -qq -y $PKGS >/dev/null 2>&1
         elif command -v dnf >/dev/null 2>&1; then
             # Fedora/RHEL
             PKGS=""
             [ $NEED_ALSA -eq 1 ] && PKGS="$PKGS alsa-lib" && echo "installing alsa-lib..."
             [ $NEED_FFMPEG -eq 1 ] && PKGS="$PKGS ffmpeg" && echo "installing ffmpeg..."
+            if [ $NEED_GLIB -eq 1 ] || [ $NEED_GOBJECT -eq 1 ]; then PKGS="$PKGS glib2-devel" && echo "installing glib2-devel..."; fi
             sudo dnf install -q -y $PKGS >/dev/null 2>&1
         elif command -v pacman >/dev/null 2>&1; then
             # Arch Linux
             PKGS=""
             [ $NEED_ALSA -eq 1 ] && PKGS="$PKGS alsa-lib" && echo "installing alsa-lib..."
             [ $NEED_FFMPEG -eq 1 ] && PKGS="$PKGS ffmpeg" && echo "installing ffmpeg..."
+            if [ $NEED_GLIB -eq 1 ] || [ $NEED_GOBJECT -eq 1 ]; then PKGS="$PKGS glib2" && echo "installing glib2..."; fi
             sudo pacman -S --noconfirm --quiet $PKGS >/dev/null 2>&1
         elif command -v zypper >/dev/null 2>&1; then
             # OpenSUSE
             PKGS=""
             [ $NEED_ALSA -eq 1 ] && PKGS="$PKGS alsa-lib" && echo "installing alsa-lib..."
             [ $NEED_FFMPEG -eq 1 ] && PKGS="$PKGS ffmpeg" && echo "installing ffmpeg..."
+            if [ $NEED_GLIB -eq 1 ] || [ $NEED_GOBJECT -eq 1 ]; then PKGS="$PKGS glib2-devel" && echo "installing glib2-devel..."; fi
             sudo zypper --quiet --non-interactive install $PKGS >/dev/null 2>&1
         fi
     fi

--- a/screenpipe-app-tauri/scripts/pre_build.cjs
+++ b/screenpipe-app-tauri/scripts/pre_build.cjs
@@ -4,7 +4,7 @@ const os = require("os");
 
 const root = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(root, "..");
-const destDir = path.join(root, "src-tauri", "bin");
+const destDir = path.join(root, "src-tauri", "binaries");
 
 const plat = os.platform();
 const envTriple = process.env.SCREENPIPE_TARGET_TRIPLE;
@@ -36,14 +36,14 @@ if (!src) {
   }
 }
 
+fs.mkdirSync(destDir, { recursive: true });
+
+const dest = path.join(destDir, plat === "win32" ? `screenpipe-${triple}.exe` : `screenpipe-${triple}`);
 if (!src) {
   console.error("screenpipe binary not found", { candidates, triple });
   process.exit(1);
 }
 
-fs.mkdirSync(destDir, { recursive: true });
-
-const dest = path.join(destDir, plat === "win32" ? `screenpipe-${triple}.exe` : `screenpipe-${triple}`);
 fs.copyFileSync(src, dest);
 
 if (plat !== "win32") {

--- a/screenpipe-vision/src/microsoft.rs
+++ b/screenpipe-vision/src/microsoft.rs
@@ -29,7 +29,7 @@ pub async fn perform_ocr_windows(image: &DynamicImage) -> Result<(String, String
     writer.FlushAsync()?.await?;
     stream.Seek(0)?;
 
-    let decoder = BitmapDecoder::CreateWithIdAsync(&BitmapDecoder::PngDecoderId()?, &stream)?.await?;
+    let decoder = BitmapDecoder::CreateWithIdAsync(BitmapDecoder::PngDecoderId()?, &stream)?.await?;
 
     let bitmap: SoftwareBitmap = decoder.GetSoftwareBitmapAsync()?.await?;
 


### PR DESCRIPTION
## Summary
- stop creating placeholder for missing sidecar and exit on missing binary
- ensure Linux installer checks for glib and gobject packages
- document glib and gobject requirements in README

## Testing
- `node screenpipe-app-tauri/scripts/pre_build.cjs` *(fails: screenpipe binary not found)*
- `cargo check --manifest-path screenpipe-app-tauri/src-tauri/Cargo.toml` *(terminated: long dependency fetch)*
- `cargo check -p screenpipe-vision --no-default-features` *(terminated: long build)*

------
https://chatgpt.com/codex/tasks/task_e_68a48fbfaa38832d8f6bd10c652a380d