### PR TITLE
chore: quiet build logs in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           export PKG_CONFIG_ALLOW_CROSS=1
           export RUSTFLAGS="-Awarnings -C link-arg=-Wl,-rpath,@executable_path/../lib -C link-arg=-Wl,-rpath,@loader_path/../lib"
           export RUSTDOCFLAGS=-Awarnings
-          cargo build --release -p screenpipe-server --target aarch64-apple-darwin
+          cargo build --release -p screenpipe-server --target aarch64-apple-darwin --quiet
       - run: node ./scripts/pre_build.cjs
         working-directory: screenpipe-app-tauri
       - run: |
@@ -63,7 +63,7 @@ jobs:
         working-directory: screenpipe-app-tauri
       - run: pnpm run build
         working-directory: screenpipe-app-tauri
-      - run: pnpm run tauri build
+      - run: pnpm run tauri build -- --quiet
         working-directory: screenpipe-app-tauri
       - uses: actions/upload-artifact@v4
         with:
@@ -156,7 +156,7 @@ jobs:
         working-directory: screenpipe-app-tauri
       - run: pnpm run build
         working-directory: screenpipe-app-tauri
-      - run: pnpm run tauri build -- -vvv
+      - run: pnpm run tauri build -- --quiet
         working-directory: screenpipe-app-tauri
         env:
           APPIMAGE_EXTRACT_AND_RUN: '1'
@@ -231,7 +231,7 @@ jobs:
           echo CMAKE_MSVC_RUNTIME_LIBRARY=$env:CMAKE_MSVC_RUNTIME_LIBRARY
           echo RUSTFLAGS=$env:RUSTFLAGS
         shell: pwsh
-      - run: cargo build --release --target x86_64-pc-windows-msvc -vv
+      - run: cargo build --release --target x86_64-pc-windows-msvc --quiet
         shell: pwsh
         env:
           RUSTFLAGS: -Ctarget-feature=-crt-static -Awarnings
@@ -268,7 +268,7 @@ jobs:
       - run: |
           if (!(Test-Path screenpipe-app-tauri\src-tauri\binaries\screenpipe-x86_64-pc-windows-msvc.exe)) { exit 1 }
         shell: pwsh
-      - run: pnpm run tauri build
+      - run: pnpm run tauri build -- --quiet
         working-directory: screenpipe-app-tauri
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- add `--quiet` flag to macOS cargo and Tauri build steps
- add `--quiet` flag to Windows cargo and Tauri build steps

## Testing
- `yamllint .github/workflows/build.yml` *(fails: line-length issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f96fd73c832d806aa66fc32754d7