### PR TITLE
fix: adjust binary paths for build

### DIFF
--- a/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
@@ -14,11 +14,9 @@
             },
             "appimage": {
                 "files": {
-                    "/usr/bin/tesseract": "./tesseract",
-                    "/usr/bin/ffmpeg": "./ffmpeg/ffmpeg",
-                    "/usr/bin/ffprobe": "./ffmpeg/ffprobe",
-                    "/usr/bin/qt-faststart": "./ffmpeg/qt-faststart",
-                    "/usr/bin/model": "./ffmpeg/model/"
+                    "/usr/bin/tesseract": "binaries/tesseract",
+                    "/usr/bin/ffmpeg": "binaries/ffmpeg",
+                    "/usr/bin/ffprobe": "binaries/ffprobe"
                 }
             }
         }


### PR DESCRIPTION
## Summary
- copy tesseract, ffmpeg and ffprobe binaries without target triple for Linux builds
- reference exact binary paths in Linux AppImage configuration

## Testing
- `node --check screenpipe-app-tauri/scripts/pre_build.cjs`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a50f8bac70832da47ba21e53237236