### PR TITLE
fix: correct binary paths for builds

### DIFF
--- a/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
@@ -14,7 +14,7 @@
             },
             "appimage": {
                 "files": {
-                    "/usr/bin/tesseract": "binaries/tesseract",
+                    "/usr/bin/tesseract": "tesseract",
                     "/usr/bin/ffmpeg": "binaries/ffmpeg",
                     "/usr/bin/ffprobe": "binaries/ffprobe"
                 }


### PR DESCRIPTION
## Summary
- copy tesseract to expected linux path
- handle nested ONNX Runtime files on Windows

## Testing
- `node screenpipe-app-tauri/scripts/pre_build.cjs` *(fails: screenpipe binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a520ced984832d8d5695927bed60cc