### PR TITLE
Align Tauri versions and Linux binary paths

### DIFF
--- a/screenpipe-app-tauri/package-lock.json
+++ b/screenpipe-app-tauri/package-lock.json
@@ -70,7 +70,7 @@
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.13",
-        "@tauri-apps/cli": "^2.8.0",
+        "@tauri-apps/cli": "2.7.0",
         "@types/lodash": "^4.17.7",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -2606,9 +2606,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.8.0.tgz",
-      "integrity": "sha512-2k1xCIDVaqtQ4b0mNUbr22JyPR2EnA/o3FsHf6sT53+5FIK+yzDC17gGopUJ3ikCvvverZ/83phmno0t4KFwUw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.7.0.tgz",
+      "integrity": "sha512-ozyxKm5YvivvLyrgHKyl6L+6y1/TkkeoA0cppPqxDv+ldbbtYiXx7dH8/G20tINh7dE+omSimN36i9M1ClGxtQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -2622,23 +2622,23 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.8.0",
-        "@tauri-apps/cli-darwin-x64": "2.8.0",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.8.0",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.8.0",
-        "@tauri-apps/cli-linux-arm64-musl": "2.8.0",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.8.0",
-        "@tauri-apps/cli-linux-x64-gnu": "2.8.0",
-        "@tauri-apps/cli-linux-x64-musl": "2.8.0",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.8.0",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.8.0",
-        "@tauri-apps/cli-win32-x64-msvc": "2.8.0"
+        "@tauri-apps/cli-darwin-arm64": "2.7.0",
+        "@tauri-apps/cli-darwin-x64": "2.7.0",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.7.0",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.7.0",
+        "@tauri-apps/cli-linux-arm64-musl": "2.7.0",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.7.0",
+        "@tauri-apps/cli-linux-x64-gnu": "2.7.0",
+        "@tauri-apps/cli-linux-x64-musl": "2.7.0",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.7.0",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.7.0",
+        "@tauri-apps/cli-win32-x64-msvc": "2.7.0"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.8.0.tgz",
-      "integrity": "sha512-+Ab2XNCTcJztTGM+1ym4uIDGOH7r6tYxwjDqa9/KxkrHdRYeoMxVBa5zQHsnJ/KXfynqagK86t61ys8Ei/tv0Q==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.7.0.tgz",
+      "integrity": "sha512-4sSrBlZuGb78UKkVQHdexzrYCamsiFQXFFuh9EI8vdq9PgTG8oXByQNIMx+p01HB594kLhaySrgozst6EFPoVQ==",
       "cpu": [
         "arm64"
       ],
@@ -2653,9 +2653,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.8.0.tgz",
-      "integrity": "sha512-DrBK3tf+CWmYC3ma+mhYn7LbXiPARLx27SjYCaErRK6/4hgmOgD0xrDhcRhYT2w7uY1iPhsfkx+ZOWQexH9qOw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.7.0.tgz",
+      "integrity": "sha512-Uec0pKyw5/w4UmcRLyPt/+JG4dsIKj0TeKtF3PDz4EAGOevjSBaLIgu8aC62s3wKLCtDydTdIMMQ1ENHTJgfPA==",
       "cpu": [
         "x64"
       ],
@@ -2670,9 +2670,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.8.0.tgz",
-      "integrity": "sha512-ZlvSgEcYNQBn07dY+4QOChobnJwVtElMSI7NH+oA6x7pQu2n5JVW7Mu3nntIA05IDEArVVURGA/walDuoR0wIQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.7.0.tgz",
+      "integrity": "sha512-ZE7y/3MW9i1DccnHyktBDbryMWVFdnIfdqQoJ40iBzQGoBIQk4DonA5zROcqw0qGRTsXfTRnVjIXnh5eLkoCzQ==",
       "cpu": [
         "arm"
       ],
@@ -2687,9 +2687,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.8.0.tgz",
-      "integrity": "sha512-wSQgTDFVJjXDMPrh/Muzl5p1JKAsSUhlT12HYDEc5aEmNHxWH0ng4Gp0QADhwlzUZkiJMqvMva2HzJijQnjELA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.7.0.tgz",
+      "integrity": "sha512-cWGl8OL+FjPWib+K8YK1S6o2Z34+f2LxnFRziTPdHwrdlVNO2xYkJmrT6X3PyHtccf/IByicxVvjkExLlpZ4+A==",
       "cpu": [
         "arm64"
       ],
@@ -2704,9 +2704,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.8.0.tgz",
-      "integrity": "sha512-/bC/v5SzT2pmfWh8NhIaFx0ON4UcdI3LpDjuXeU4y+rXFXRAKKdKnKBshReHr6KC9UxzS8wGSsSe2eTfJnyXWw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.7.0.tgz",
+      "integrity": "sha512-MftwAsMDw9dmKosbHdSHyCa0jgKjt9UslJsRpXym8dmbw+gzD3YrY41GORq0HbCYImC5rS/qQf9eELoLcqY/BQ==",
       "cpu": [
         "arm64"
       ],
@@ -2721,9 +2721,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.8.0.tgz",
-      "integrity": "sha512-hzzsrGp3SXXLuJZdjcq1mAmzr9MaBEQy1DYGEn/HEBiwE8EY1Ou27sBistGkl+X/vusmGwgmLuRKe9Mtbb7mNQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.7.0.tgz",
+      "integrity": "sha512-QwL4YhckgtozR7wlXOTRKijkgViz4B0OeXqhsIrhQock2HDxqCh5VqhGQ9LRJ6HsXY1JkAYZQUAFvcBj2DHUXQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2738,9 +2738,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.8.0.tgz",
-      "integrity": "sha512-5z0uKFYGcy8pW8dDooRExmCtunz9BEVETlbNTaarTeXueGk1t3jH43k3uQ0/gIeYvL0X/8oWf848CzJdTSpoLQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.7.0.tgz",
+      "integrity": "sha512-4MwN2sqUEYGKjwcs0afPp79DkiydAfkGNdBTPfvNrDUmhbT6JE95RhYyzfZLfXNinsdB4nbZmYGEPIv5NpK2KQ==",
       "cpu": [
         "x64"
       ],
@@ -2755,9 +2755,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.8.0.tgz",
-      "integrity": "sha512-7uHwJUhE5e9NqSPrjAuN69X+I32uxN0V3UGwUB6eLhV7MhCyjroqVdfFqOkIT2rUE/OtSGQiUO7z0ZGfY3OIdQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.7.0.tgz",
+      "integrity": "sha512-N1hygCRW0X4msCpdG3/UXb+Z8wpc4lYRqlkhbbxLOjzHwjuLS+86GYAvRLe7JIePVXVUI5BfX1HeurdbWWINTg==",
       "cpu": [
         "x64"
       ],
@@ -2772,9 +2772,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.8.0.tgz",
-      "integrity": "sha512-Emzj0BswRbKp3daDZWS7jbiSzJ0pUcaXFIQYC8sHc34vQe4RwbHZc99XKf+J6XRAznXs0piDvW9HQbXs3uVvXA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.7.0.tgz",
+      "integrity": "sha512-sqVDkwvUsuHeUVlMXpkXPo4gWFXuOcNbme0xPQ1r07hqBxYJlqwDY9XS0sC/7XljnO6anJaSr8FJkuixnIqyUQ==",
       "cpu": [
         "arm64"
       ],
@@ -2789,9 +2789,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.8.0.tgz",
-      "integrity": "sha512-xHWSyiZCzyc5+7djVaB1soOTe++c/siTZ0EC05Or7QYQRQsKRxDpeTCgheN7Z/Sv1cdlvkK1OZgp4+ddB4hTCA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.7.0.tgz",
+      "integrity": "sha512-2sZFAZZC8fwc65d5ACrTUgKPYbZgd3DAN5gI4WzCyTQgPqLq/7CWD25Wt7+scTV7FhT1zjL88hI10yPsEE0kkA==",
       "cpu": [
         "ia32"
       ],
@@ -2806,9 +2806,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.8.0.tgz",
-      "integrity": "sha512-EpkyVj2idqQthfxkjYcLRTaFM+TluywD4RbdVfjnLE060vPM6LYPouDizYZqXRfEsd5LCi1/VAcsqTK9BAC/zA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.7.0.tgz",
+      "integrity": "sha512-mGqRRpqdZ5iKLaQwP1paz89koLVrE/mUOrq6boftHDxF8K1sU/9Um/E7SLrkfeICiWbVG5yY7j2N/j8/D80blw==",
       "cpu": [
         "x64"
       ],

--- a/screenpipe-app-tauri/package.json
+++ b/screenpipe-app-tauri/package.json
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.13",
-    "@tauri-apps/cli": "^2.8.0",
+    "@tauri-apps/cli": "2.7.0",
     "@types/lodash": "^4.17.7",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -1447,7 +1447,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1665,7 +1665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3248,7 +3248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5204,7 +5204,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.84"
 tauri-build = { version = "=2.4.0", features = [] }
 
 [dependencies]
-tauri = { version = "2.6.0", features = [
+tauri = { version = "2.7.0", features = [
   "protocol-asset",
   "macos-private-api",
   "devtools",
@@ -91,7 +91,7 @@ tauri-plugin-cli = "2.4.0"
 tauri-plugin-global-shortcut = "2.3.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
-tauri = { version = "2.6.0", features = ["tray-icon", "wry"], default-features = false }
+tauri = { version = "2.7.0", features = ["tray-icon", "wry"], default-features = false }
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]
 tauri-plugin-single-instance = { version = "2.3.2", features = ["deep-link"] }

--- a/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
@@ -15,8 +15,8 @@
             "appimage": {
                 "files": {
                     "/usr/bin/tesseract": "tesseract",
-                    "binaries/ffmpeg": "/usr/bin/ffmpeg",
-                    "binaries/ffprobe": "/usr/bin/ffprobe"
+                    "binaries/ffmpeg-${triple}": "/usr/bin/ffmpeg",
+                    "binaries/ffprobe-${triple}": "/usr/bin/ffprobe"
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fix AppImage config to reference platform-suffixed ffmpeg and ffprobe binaries
- align Tauri core crates and CLI around the 2.7 release

## Testing
- `cargo update -p tauri --precise 2.7.0`
- `cargo update -p tauri-utils --precise 2.7.0`
- `npm install --package-lock-only`
- `cargo check` *(fails: terminated to keep runtime reasonable)*

------
https://chatgpt.com/codex/tasks/task_e_68a54b0cbe34832d9f243915d7290d7c