### PR TITLE
Fix AppImage bundling on Linux

### DIFF
--- a/screenpipe-app-tauri/package.json
+++ b/screenpipe-app-tauri/package.json
@@ -5,11 +5,12 @@
     "dev": "next dev",
     "test:e2e": "wdio run wdio.conf.js",
     "test:e2e:terminator": "mocha",
+    "test:bundler-deps": "sh ../scripts/test-bundler-deps.sh",
     "build": "next build",
     "predev": "node scripts/pre_build.cjs",
     "prebuild": "node scripts/pre_build.cjs",
     "pretauri": "node scripts/pre_build.cjs",
-    "tauri": "cross-env TAURI_LOG_LEVEL=warn tauri",
+    "tauri": "cross-env APPIMAGE_EXTRACT_AND_RUN=1 TAURI_LOG_LEVEL=warn tauri",
     "clean": "rm -rf out && cargo clean && rm -rf src-tauri/{screenpipe-*,tesseract-*,ffmpeg*,bun*,ollama*,ui_monitor*} node_modules"
   },
   "dependencies": {

--- a/scripts/test-bundler-deps.sh
+++ b/scripts/test-bundler-deps.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+if [ "$APPIMAGE_EXTRACT_AND_RUN" != "1" ] && [ ! -e /dev/fuse ]; then
+  echo missing fuse
+  exit 1
+fi
+if [ "$APPIMAGE_EXTRACT_AND_RUN" != "1" ] && ! ldconfig -p | grep -q libfuse; then
+  echo missing libfuse
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- run linuxdeploy without FUSE by extracting the AppImage
- add bundler dependency check script

## Testing
- `APPIMAGE_EXTRACT_AND_RUN=1 pnpm run test:bundler-deps`

------
https://chatgpt.com/codex/tasks/task_e_68a572ed0894832d913e533a0beaa5c1