### PR TITLE
fix windows onnxruntime extraction

### DIFF
--- a/screenpipe-app-tauri/scripts/pre_build.cjs
+++ b/screenpipe-app-tauri/scripts/pre_build.cjs
@@ -97,8 +97,11 @@ if (plat === "win32") {
       process.exit(1);
     }
     fs.rmSync(pkgDir, { recursive: true, force: true });
-    fs.mkdirSync(pkgDir, { recursive: true });
-    fs.cpSync(inner, pkgDir, { recursive: true });
+    fs.cpSync(path.join(inner, '.'), pkgDir, { recursive: true });
+    if (!fs.existsSync(path.join(pkgDir, "lib", "onnxruntime.dll"))) {
+      console.error("onnxruntime.dll not found");
+      process.exit(1);
+    }
     fs.rmSync(tmp, { recursive: true, force: true });
     fs.unlinkSync(zip);
   }


### PR DESCRIPTION
## Summary
- copy extracted onnxruntime package contents directly into target directory on Windows
- verify onnxruntime.dll exists after extraction

## Testing
- `SCREENPIPE_PLATFORM=win32 SCREENPIPE_TARGET_TRIPLE=x86_64-pc-windows-msvc node screenpipe-app-tauri/scripts/pre_build.cjs`
- `ls target/x86_64-pc-windows-msvc/release`


------
https://chatgpt.com/codex/tasks/task_e_68a576cfc744832da419076c5e973d54