### PR TITLE
Ensure onnxruntime DLL exists before copying

### DIFF
--- a/screenpipe-app-tauri/scripts/pre_build.cjs
+++ b/screenpipe-app-tauri/scripts/pre_build.cjs
@@ -107,8 +107,9 @@ if (plat === "win32") {
     fs.rmSync(tmp, { recursive: true, force: true });
     fs.unlinkSync(zip);
   }
-  if (!fs.existsSync(path.join(pkgDir, "lib", "onnxruntime.dll"))) {
-    console.error("onnxruntime.dll not found");
+  const coreLib = path.join(pkgDir, "lib", "onnxruntime.dll");
+  if (!fs.existsSync(coreLib)) {
+    console.error("onnxruntime.dll not found", { coreLib });
     process.exit(1);
   }
   for (const lib of libs) {
@@ -117,6 +118,8 @@ if (plat === "win32") {
       console.error(`${lib} not found`, { srcLib });
       process.exit(1);
     }
-    fs.copyFileSync(srcLib, path.join(srcDir, lib));
+    const destLib = path.join(srcDir, lib);
+    console.log("copying", { src: srcLib, dest: destLib });
+    fs.copyFileSync(srcLib, destLib);
   }
 }


### PR DESCRIPTION
## Summary
- verify presence of onnxruntime.dll before copy
- log source and destination for Windows ONNX runtime libs

## Testing
- `pnpm run tauri build -- --quiet` *(fails: screenpipe binary not found)*
- `SCREENPIPE_PLATFORM=win32 SCREENPIPE_TARGET_TRIPLE=x86_64-pc-windows-msvc BUN_INSTALL=$HOME/.bun node scripts/pre_build.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68a58ac959a8832d81897529c9825871