### PR TITLE
ci: guard pkg-config unlink in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,8 @@ jobs:
           cargo tree -e features -i ort
       - run: printenv | sort
       - run: cargo metadata --no-deps --format-version=1 | jq -r '.packages[].name'
-      - run: brew unlink pkg-config@0.29.2 || true
+      - run: |
+          if brew list pkg-config@0.29.2 &>/dev/null; then brew unlink pkg-config@0.29.2; fi
       - run: brew install ffmpeg pkg-config
       - run: brew link --overwrite pkg-config
       - run: |


### PR DESCRIPTION
## Summary
- check for pkg-config keg before unlinking to avoid brew warnings

## Testing
- `~/.local/bin/yamllint .github/workflows/build.yml`
- `bash -lc 'if brew list pkg-config@0.29.2 &>/dev/null; then brew unlink pkg-config@0.29.2; fi'`


------
https://chatgpt.com/codex/tasks/task_e_68a58adf4070832dac610a7fd857aa00