### PR TITLE
fix: refresh ORT DLLs on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,6 +254,11 @@ jobs:
           Copy-Item "target\x86_64-pc-windows-msvc\release\screenpipe.exe" "screenpipe-app-tauri\src-tauri\binaries\screenpipe-x86_64-pc-windows-msvc.exe"
           Get-ChildItem "screenpipe-app-tauri\src-tauri\binaries"
         shell: pwsh
+      - name: Clean stale ORT symlinks
+        shell: pwsh
+        run: |
+          $p = "$env:GITHUB_WORKSPACE\target\x86_64-pc-windows-msvc\release"
+          if (Test-Path $p) { Get-ChildItem $p -Filter "onnxruntime*.dll" -Force | Remove-Item -Force }
       - run: |
           Get-ChildItem 'src-tauri\onnxruntime-win-x64-gpu-1.22.0' -Recurse
           try {

--- a/screenpipe-app-tauri/scripts/pre_build.cjs
+++ b/screenpipe-app-tauri/scripts/pre_build.cjs
@@ -21,6 +21,12 @@ const defaultTriple =
 const triple = envTriple || defaultTriple;
 const ext = plat === "win32" ? ".exe" : "";
 
+function copyFresh(src, dest) {
+  try { fs.rmSync(dest, { force: true }); } catch {}
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+}
+
 function copy(src, base, plain, dir) {
   const targetDir = dir || destDir;
   const dest = path.join(targetDir, plain ? `${base}${ext}` : `${base}-${triple}${ext}`);
@@ -28,8 +34,7 @@ function copy(src, base, plain, dir) {
     console.error(`${base} binary not found`, { src, triple });
     process.exit(1);
   }
-  fs.mkdirSync(targetDir, { recursive: true });
-  fs.copyFileSync(src, dest);
+  copyFresh(src, dest);
   if (plat !== "win32") {
     try { fs.chmodSync(dest, 0o755); } catch {}
   }
@@ -123,6 +128,6 @@ if (plat === "win32") {
     }
     const destLib = path.join(srcDir, lib);
     console.log("copying", { src: srcLib, dest: destLib });
-    fs.copyFileSync(srcLib, destLib);
+    copyFresh(srcLib, destLib);
   }
 }


### PR DESCRIPTION
## Summary
- remove stale ONNX Runtime DLL symlinks before copying
- copy fresh ONNX Runtime DLLs during build to avoid ENOENT

## Testing
- `node --check screenpipe-app-tauri/scripts/pre_build.cjs`
- `pnpm test` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_68a5a79f2424832db85d84fb1f2ef013