### PR TITLE
fix: install gstreamer dev packages for linux appimage build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         working-directory: screenpipe-app-tauri
       - run: pnpm run build
         working-directory: screenpipe-app-tauri
-      - run: pnpm run tauri build -- --quiet
+      - run: pnpm run tauri build -- --verbose
         working-directory: screenpipe-app-tauri
       - uses: actions/upload-artifact@v4
         with:
@@ -105,16 +105,18 @@ jobs:
             libasound2-dev libudev-dev libpulse-dev curl pkg-config libsqlite3-dev libbz2-dev zlib1g-dev \
             libonig-dev libayatana-appindicator3-dev libsamplerate-dev libwebrtc-audio-processing-dev \
             libgtk-3-dev librsvg2-dev patchelf libdbus-1-dev libfuse2 gstreamer1.0-libav \
+            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
             gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly \
             gstreamer1.0-tools libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev \
             libglib2.0-bin libgdk-pixbuf2.0-bin libgtk-3-bin desktop-file-utils appstream
       - run: |
           export PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:$PKG_CONFIG_PATH"
-          pkg-config --version
-          pkg-config --modversion dbus-1 || true
-          pkg-config --modversion alsa
-          echo PKG_CONFIG_PATH=$PKG_CONFIG_PATH
-          ls -la /usr/lib/x86_64-linux-gnu/pkgconfig | head -n 120
+            pkg-config --version
+            pkg-config --modversion dbus-1 || true
+            pkg-config --modversion alsa
+            pkg-config --modversion gstreamer-1.0 gstreamer-plugins-base-1.0
+            echo PKG_CONFIG_PATH=$PKG_CONFIG_PATH
+            ls -la /usr/lib/x86_64-linux-gnu/pkgconfig | head -n 120
       - run: pkg-config --modversion webkit2gtk-4.1
       - uses: pnpm/action-setup@v3
         with:
@@ -157,7 +159,7 @@ jobs:
         working-directory: screenpipe-app-tauri
       - run: pnpm run build
         working-directory: screenpipe-app-tauri
-      - run: pnpm run tauri build -- --quiet
+      - run: pnpm run tauri build -- --verbose
         working-directory: screenpipe-app-tauri
         env:
           APPIMAGE_EXTRACT_AND_RUN: '1'
@@ -317,7 +319,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path $dst | Out-Null
           Copy-Item (Join-Path $crt "*.dll") $dst -Force
           Get-ChildItem $dst
-      - run: pnpm run tauri build -- --quiet
+      - run: pnpm run tauri build -- --verbose
         working-directory: screenpipe-app-tauri
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -329,6 +329,8 @@ jobs:
             patchelf \
             libfuse2 \
             gstreamer1.0-libav \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
             gstreamer1.0-plugins-bad \
             gstreamer1.0-plugins-base \
             gstreamer1.0-plugins-good \
@@ -350,6 +352,9 @@ jobs:
           wget https://launchpadlibrarian.net/587202140/libjpeg-turbo8_2.1.2-0ubuntu1_amd64.deb
           wget https://launchpadlibrarian.net/592959859/xdg-desktop-portal-gtk_1.14.0-1build1_amd64.deb
           sudo apt-get install -y /tmp/ubuntu-packages/*.deb
+
+      - run: pkg-config --modversion gstreamer-1.0 gstreamer-plugins-base-1.0
+        if: matrix.os_type == 'linux'
 
       - name: Install frontend dependencies
         working-directory: ./screenpipe-app-tauri

--- a/screenpipe-app-tauri/src-tauri/tauri.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.conf.json
@@ -36,7 +36,10 @@
     "resources": [
       "assets/*",
       "vcredist/*"
-    ]
+    ],
+    "appimage": {
+      "bundleMediaFramework": true
+    }
   },
   "plugins": {
     "deep-link": {


### PR DESCRIPTION
## Summary
- install GStreamer development packages in build and release workflows
- verify GStreamer presence via pkg-config
- enable AppImage media framework bundling and use verbose builds

## Testing
- `npm run test:bundler-deps` *(fails: missing fuse)*
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b1bd7f38832d81d2727f55fbadca