### PR TITLE
fix: resolve vswhere path and invalid appimage config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,7 +310,7 @@ jobs:
       - name: Stage MSVC CRT
         shell: pwsh
         run: |
-          $pws = "$Env:ProgramFiles(x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+          $pws = "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $vs  = & $pws -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
           $red = Join-Path $vs "VC\Redist\MSVC"
           $ver = (Get-ChildItem $red -Directory | Sort-Object Name -Descending | Select-Object -First 1).FullName

--- a/screenpipe-app-tauri/src-tauri/tauri.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.conf.json
@@ -37,8 +37,10 @@
       "assets/*",
       "vcredist/*"
     ],
-    "appimage": {
-      "bundleMediaFramework": true
+    "linux": {
+      "appimage": {
+        "bundleMediaFramework": true
+      }
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary
- fix Windows build workflow to properly resolve vswhere path
- place AppImage options under bundle.linux in Tauri configuration

## Testing
- `pnpm install`
- `pnpm run tauri build -- --verbose` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b826b1f8832db468c94434a3cfde