### PR TITLE
ci: add WebKitGTK 4.0 package to linux workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
             libgtk-3-dev librsvg2-dev patchelf libdbus-1-dev libfuse2 gstreamer1.0-libav \
             libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
             gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly \
-            gstreamer1.0-tools libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev \
+            gstreamer1.0-tools libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev \
             libglib2.0-bin libgdk-pixbuf2.0-bin libgtk-3-bin desktop-file-utils appstream \
             libunwind-dev
           dpkg -l | egrep 'libunwind|libc\+\+' || true

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -324,6 +324,7 @@ jobs:
             libayatana-appindicator3-dev \
             libsamplerate-dev \
             libwebrtc-audio-processing-dev \
+            libwebkit2gtk-4.0-dev \
             libgtk-3-dev \
             librsvg2-dev \
             patchelf \


### PR DESCRIPTION
## Summary
- ensure Linux GitHub Actions install WebKitGTK 4.0 development package for Tauri builds

## Testing
- `cargo test -p screenpipe-vision --all-features --no-fail-fast` *(fails: The system library `dbus-1` required by crate `libdbus-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a60750fccc832dbdb92e19f5ebf14b