### PR TITLE
Use VC++ redistributable installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,33 +312,14 @@ jobs:
       - run: |
           if (!(Test-Path screenpipe-app-tauri\src-tauri\binaries\screenpipe-x86_64-pc-windows-msvc.exe)) { exit 1 }
         shell: pwsh
-      - name: Stage MSVC CRT
+      - name: Download VC++ Redistributable
         shell: pwsh
         run: |
-            $pws = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-            if (-not (Test-Path $pws)) { $pws = "${env:ProgramFiles}\Microsoft Visual Studio\Installer\vswhere.exe" }
-            $vs = ""
-            if (Test-Path $pws) { $vs = & "$pws" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Redist.14.Latest -property installationPath }
-            if (-not $vs -and (Test-Path $pws)) { $vs = & "$pws" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath }
-            if (-not $vs) {
-              $roots = @("${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022","${env:ProgramFiles}\Microsoft Visual Studio\2022","${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019","${env:ProgramFiles}\Microsoft Visual Studio\2019")
-              $eds = @("Enterprise","Professional","Community","BuildTools")
-              foreach ($r in $roots) {
-                foreach ($e in $eds) {
-                  $cand = Join-Path $r $e
-                  if (Test-Path (Join-Path $cand "VC\Redist\MSVC")) { $vs = $cand; break }
-                }
-                if ($vs) { break }
-              }
-            }
-            $red = Join-Path $vs "VC\Redist\MSVC"
-            $ver = (Get-ChildItem $red -Directory | Sort-Object Name -Descending | Select-Object -First 1).FullName
-            $crt = (Get-ChildItem (Join-Path $ver "x64") -Directory -Filter "Microsoft.VC*.CRT" | Sort-Object Name -Descending | Select-Object -First 1).FullName
-            $omp = (Get-ChildItem (Join-Path $ver "x64") -Directory -Filter "Microsoft.VC*.OpenMP" | Sort-Object Name -Descending | Select-Object -First 1).FullName
             $dst = "$env:GITHUB_WORKSPACE\screenpipe-app-tauri\src-tauri\vcredist"
             New-Item -ItemType Directory -Force -Path $dst | Out-Null
-            Copy-Item (Join-Path $crt "*.dll") $dst -Force
-            if (Test-Path $omp) { Copy-Item (Join-Path $omp "*.dll") $dst -Force }
+            $url = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+            $output = Join-Path $dst "vc_redist.x64.exe"
+            Invoke-WebRequest -Uri $url -OutFile $output
             Get-ChildItem $dst
       - run: pnpm run tauri build -- --quiet
         working-directory: screenpipe-app-tauri

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -128,33 +128,14 @@ jobs:
         }
         Remove-Item -Path $temp_dir -Recurse -Force
 
-    - name: Copy library for vcredist
+    - name: Download VC++ Redistributable
       shell: pwsh
       run: |
-        $pws = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-        if (-not (Test-Path $pws)) { $pws = "${env:ProgramFiles}\Microsoft Visual Studio\Installer\vswhere.exe" }
-        $vs = ""
-        if (Test-Path $pws) { $vs = & "$pws" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Redist.14.Latest -property installationPath }
-        if (-not $vs -and (Test-Path $pws)) { $vs = & "$pws" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath }
-        if (-not $vs) {
-          $roots = @("${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022","${env:ProgramFiles}\Microsoft Visual Studio\2022","${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019","${env:ProgramFiles}\Microsoft Visual Studio\2019")
-          $eds = @("Enterprise","Professional","Community","BuildTools")
-          foreach ($r in $roots) {
-            foreach ($e in $eds) {
-              $cand = Join-Path $r $e
-              if (Test-Path (Join-Path $cand "VC\Redist\MSVC")) { $vs = $cand; break }
-            }
-            if ($vs) { break }
-          }
-        }
-        $red = Join-Path $vs "VC\Redist\MSVC"
-        $ver = (Get-ChildItem $red -Directory | Sort-Object Name -Descending | Select-Object -First 1).FullName
-        $crt = (Get-ChildItem (Join-Path $ver "x64") -Directory -Filter "Microsoft.VC*.CRT" | Sort-Object Name -Descending | Select-Object -First 1).FullName
-        $omp = (Get-ChildItem (Join-Path $ver "x64") -Directory -Filter "Microsoft.VC*.OpenMP" | Sort-Object Name -Descending | Select-Object -First 1).FullName
         $dst = "$env:GITHUB_WORKSPACE\screenpipe-app-tauri\src-tauri\vcredist"
         New-Item -ItemType Directory -Force -Path $dst | Out-Null
-        Copy-Item (Join-Path $crt "*.dll") $dst -Force
-        if (Test-Path $omp) { Copy-Item (Join-Path $omp "*.dll") $dst -Force }
+        $url = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+        $output = Join-Path $dst "vc_redist.x64.exe"
+        Invoke-WebRequest -Uri $url -OutFile $output
         Get-ChildItem $dst
 
     - name: Clean stale ORT

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -524,34 +524,15 @@ jobs:
 
           Remove-Item -Path $temp_dir -Recurse -Force
 
-      - name: Copy library for vcredist
+      - name: Download VC++ Redistributable
         if: matrix.os_type == 'windows'
         shell: pwsh
         run: |
-          $pws = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          if (-not (Test-Path $pws)) { $pws = "${env:ProgramFiles}\Microsoft Visual Studio\Installer\vswhere.exe" }
-          $vs = ""
-          if (Test-Path $pws) { $vs = & "$pws" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Redist.14.Latest -property installationPath }
-          if (-not $vs -and (Test-Path $pws)) { $vs = & "$pws" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath }
-          if (-not $vs) {
-            $roots = @("${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022","${env:ProgramFiles}\Microsoft Visual Studio\2022","${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019","${env:ProgramFiles}\Microsoft Visual Studio\2019")
-            $eds = @("Enterprise","Professional","Community","BuildTools")
-            foreach ($r in $roots) {
-              foreach ($e in $eds) {
-                $cand = Join-Path $r $e
-                if (Test-Path (Join-Path $cand "VC\Redist\MSVC")) { $vs = $cand; break }
-              }
-              if ($vs) { break }
-            }
-          }
-          $red = Join-Path $vs "VC\Redist\MSVC"
-          $ver = (Get-ChildItem $red -Directory | Sort-Object Name -Descending | Select-Object -First 1).FullName
-          $crt = (Get-ChildItem (Join-Path $ver "x64") -Directory -Filter "Microsoft.VC*.CRT" | Sort-Object Name -Descending | Select-Object -First 1).FullName
-          $omp = (Get-ChildItem (Join-Path $ver "x64") -Directory -Filter "Microsoft.VC*.OpenMP" | Sort-Object Name -Descending | Select-Object -First 1).FullName
           $dst = "$env:GITHUB_WORKSPACE\screenpipe-app-tauri\src-tauri\vcredist"
           New-Item -ItemType Directory -Force -Path $dst | Out-Null
-          Copy-Item (Join-Path $crt "*.dll") $dst -Force
-          if (Test-Path $omp) { Copy-Item (Join-Path $omp "*.dll") $dst -Force }
+          $url = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+          $output = Join-Path $dst "vc_redist.x64.exe"
+          Invoke-WebRequest -Uri $url -OutFile $output
           Get-ChildItem $dst
 
       - name: Clean stale ORT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,35 +121,14 @@ before you begin:
    Remove-Item -Path $temp_dir -Recurse -Force
    ```
 7. **make sure vcredist is present on system**:
-   - make sure your in root of the project i.e screenpipe
+   - make sure you're in root of the project
 
    ```powershell
    cd screenpipe
-   $path = "C:\Windows\System32\vcruntime140.dll"
-   
-   if (-Not (Test-Path $path)) {
-       Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile -ExecutionPolicy Bypass -Command "& {
-           Set-ExecutionPolicy Bypass -Scope Process -Force
-           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-           $url = ''https://vcredist.com/install.ps1''
-           $scriptPath = ''$env:TEMP\install_vcredist.ps1''
-           Invoke-WebRequest -Uri $url -OutFile $scriptPath
-           & $scriptPath
-       }"' -Wait
-   }
-   
-   # Verify installation
-   if (-Not (Test-Path $path)) {
-       Write-Host "Installation failed. Exiting."
-       exit 1
-   }
-   
-   # Copy vcruntime140.dll to the specified directory
-   $vcredist_dir = (pwd).Path + "\screenpipe-app-tauri\src-tauri\vcredist"
-   New-Item -ItemType Directory -Force -Path $vcredist_dir | Out-Null
-   Copy-Item $path -Destination $vcredist_dir -Force
-   
-   Write-Host "vcruntime140.dll copied successfully!"
+   $dst = "screenpipe-app-tauri/src-tauri/vcredist"
+   New-Item -ItemType Directory -Force -Path $dst | Out-Null
+   $url = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+   Invoke-WebRequest -Uri $url -OutFile (Join-Path $dst "vc_redist.x64.exe")
    ```
 
 8. **build**:

--- a/screenpipe-app-tauri/src-tauri/build.rs
+++ b/screenpipe-app-tauri/src-tauri/build.rs
@@ -2,9 +2,9 @@ fn main() {
     tauri_build::build();
     #[cfg(target_os = "windows")]
     {
-        let has = glob::glob("vcredist/*.dll").unwrap().next().is_some();
+        let has = glob::glob("vcredist/vc_redist.x64.exe").unwrap().next().is_some();
         if !has {
-            panic!("vcredist dlls not found");
+            panic!("vcredist not found");
         }
     }
 }

--- a/screenpipe-app-tauri/src-tauri/tauri.windows.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.windows.conf.json
@@ -23,7 +23,7 @@
             "onnxruntime*\\lib\\onnxruntime_providers_cuda.dll": "./",
             "onnxruntime*\\lib\\onnxruntime_providers_shared.dll": "./",
             "mkl\\*.dll": "./",
-            "vcredist\\*.dll": "./",
+            "vcredist\\vc_redist.x64.exe": "./",
             "assets/*": "./assets/"
         }
     }


### PR DESCRIPTION
## Summary
- switch Windows workflows to download official VC++ redistributable installer
- package redistributable installer instead of CRT DLLs

## Testing
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a64ffb8330832d85a7900d0939b7af