### PR TITLE
fix: adjust linux build requirements

### DIFF
--- a/screenpipe-app-tauri/README.md
+++ b/screenpipe-app-tauri/README.md
@@ -1,3 +1,24 @@
 
-refer to the [official documentation](https://docs.screenpi.pe/getting-started) for more information.
+Refer to the [official documentation](https://docs.screenpi.pe/getting-started) for more information.
+
+## Linux build requirements
+
+Before building the Tauri application on Linux, install the required development packages:
+
+```bash
+sudo apt install libwebkit2gtk-4.1-dev \
+    libgtk-3-dev libayatana-appindicator3-dev \
+    librsvg2-dev libssl-dev build-essential fuse
+```
+
+AppImage packaging requires FUSE and access to `/dev/fuse`. In restricted environments, set `APPIMAGE_EXTRACT_AND_RUN=1`.
+
+If bundling the media framework is needed, also install:
+
+```bash
+sudo apt install gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+    gstreamer1.0-libav patchelf
+```
+
+Make sure the Tauri CLI version matches the Rust crate version and avoid stripping the binary before packaging.
 

--- a/screenpipe-app-tauri/package.json
+++ b/screenpipe-app-tauri/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.13",
-    "@tauri-apps/cli": "^2.8.1",
+    "@tauri-apps/cli": "^2.8.2",
     "@types/lodash": "^4.17.7",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -146,4 +146,4 @@ ignored = ["tauri-utils"]
 codegen-units = 1
 lto = true
 opt-level = "s"
-strip = true
+strip = false

--- a/screenpipe-app-tauri/src-tauri/tauri.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.conf.json
@@ -38,7 +38,7 @@
       ],
     "linux": {
       "appimage": {
-        "bundleMediaFramework": true
+        "bundleMediaFramework": false
       }
     }
   },


### PR DESCRIPTION
## Summary
- disable AppImage media framework bundling
- prevent release binary stripping
- align Tauri CLI version with crate
- document Linux build dependencies and FUSE requirement for AppImage packaging

## Testing
- `pnpm test:bundler-deps`


------
https://chatgpt.com/codex/tasks/task_e_68a6192ab334832d917d3166b7deaec2