### PR TITLE
chore: downgrade tauri cli dev dependency

### DIFF
--- a/screenpipe-app-tauri/package.json
+++ b/screenpipe-app-tauri/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.13",
-    "@tauri-apps/cli": "^2.8.2",
+    "@tauri-apps/cli": "^2.8.1",
     "@types/lodash": "^4.17.7",
     "@types/node": "^20",
     "@types/react": "^19",


### PR DESCRIPTION
## Summary
- use @tauri-apps/cli v2.8.1 in screenpipe-app-tauri

## Testing
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_68a699f0930c832d840e80f371d2579a