### PR TITLE
Disable Tauri updater

### DIFF
--- a/screenpipe-app-tauri/src-tauri/tauri.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.conf.json
@@ -93,6 +93,9 @@
           ]
         }
       ]
+    },
+    "updater": {
+      "active": false
     }
   },
   "app": {


### PR DESCRIPTION
## Summary
- disable Tauri updater plugin to avoid signing requirements during build

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6a3fed654832db7456a6be93bfdd7