### PR TITLE
fix: enable media framework bundling for linux

### DIFF
--- a/screenpipe-app-tauri/src-tauri/tauri.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.conf.json
@@ -38,7 +38,7 @@
       ],
     "linux": {
       "appimage": {
-        "bundleMediaFramework": false
+        "bundleMediaFramework": true
       }
     }
   },

--- a/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
@@ -1,5 +1,10 @@
 {
     "bundle": {
+        "targets": [
+            "app",
+            "deb",
+            "appimage"
+        ],
         "externalBin": [
             "binaries/screenpipe",
             "binaries/bun"
@@ -13,6 +18,7 @@
                 ]
             },
             "appimage": {
+                "bundleMediaFramework": true,
                 "files": {
                     "/usr/bin/tesseract": "tesseract",
                     "binaries/ffmpeg-${triple}": "/usr/bin/ffmpeg",


### PR DESCRIPTION
## Summary
- bundle GStreamer media framework in Linux AppImage
- restrict Linux builds to Linux targets only

## Testing
- `cargo test --locked` *(failed: build interrupted due to time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c60b70b4832db73caf9b1fba5d8f